### PR TITLE
Add Google Workspace module skeleton

### DIFF
--- a/application/modules/google_workspace/assets/css/google_workspace.css
+++ b/application/modules/google_workspace/assets/css/google_workspace.css
@@ -1,0 +1,10 @@
+.google-workspace-dashboard {
+    padding: 20px;
+}
+.google-workspace-list {
+    list-style: none;
+    padding: 0;
+}
+.google-workspace-list li {
+    margin-bottom: 10px;
+}

--- a/application/modules/google_workspace/assets/js/google_workspace.js
+++ b/application/modules/google_workspace/assets/js/google_workspace.js
@@ -1,0 +1,4 @@
+(function(){
+    'use strict';
+    console.log('Google Workspace module loaded');
+})();

--- a/application/modules/google_workspace/config/module.php
+++ b/application/modules/google_workspace/config/module.php
@@ -1,0 +1,13 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+$config['module_name']    = 'google_workspace';
+$config['module_version'] = '1.0.0';
+
+$config['google_workspace_default_features'] = [
+    'email'    => true,
+    'calendar' => true,
+    'meet'     => true,
+    'drive'    => true,
+    'docs'     => true,
+];

--- a/application/modules/google_workspace/controllers/Google_workspace.php
+++ b/application/modules/google_workspace/controllers/Google_workspace.php
@@ -1,0 +1,64 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Google_workspace extends AdminController
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model('google_workspace/google_workspace_model');
+    }
+
+    public function index()
+    {
+        $data['title'] = _l('google_workspace');
+        $this->load->view('google_workspace/dashboard', $data);
+    }
+
+    public function email()
+    {
+        $data['title']  = _l('google_workspace_email');
+        $data['emails'] = $this->google_workspace_model->get_emails(get_staff_user_id());
+        $this->load->view('google_workspace/email', $data);
+    }
+
+    public function calendar()
+    {
+        $data['title']  = _l('google_workspace_calendar');
+        $data['events'] = $this->google_workspace_model->get_calendar_events(get_staff_user_id());
+        $this->load->view('google_workspace/calendar', $data);
+    }
+
+    public function meet()
+    {
+        $data['title']    = _l('google_workspace_meet');
+        $data['meetings'] = $this->google_workspace_model->get_meetings(get_staff_user_id());
+        $this->load->view('google_workspace/meet', $data);
+    }
+
+    public function drive()
+    {
+        $data['title'] = _l('google_workspace_drive');
+        $data['files'] = $this->google_workspace_model->get_drive_files(get_staff_user_id());
+        $this->load->view('google_workspace/drive', $data);
+    }
+
+    public function docs()
+    {
+        $data['title'] = _l('google_workspace_docs');
+        $data['docs']  = $this->google_workspace_model->get_docs(get_staff_user_id());
+        $this->load->view('google_workspace/docs', $data);
+    }
+
+    public function settings()
+    {
+        $data['title'] = _l('google_workspace_settings');
+        if ($this->input->post()) {
+            $this->google_workspace_model->update_settings($this->input->post());
+            set_alert('success', _l('updated_successfully'));
+            redirect(admin_url('google_workspace/settings'));
+        }
+        $data['settings'] = $this->google_workspace_model->get_settings();
+        $this->load->view('google_workspace/settings', $data);
+    }
+}

--- a/application/modules/google_workspace/google_workspace.php
+++ b/application/modules/google_workspace/google_workspace.php
@@ -1,0 +1,76 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Google_workspace extends Module
+{
+    public function __construct()
+    {
+        $this->module_name    = 'google_workspace';
+        $this->module_version = '1.0.0';
+        $this->app_version    = '1.0.0';
+
+        parent::__construct();
+
+        hooks()->add_action('admin_init', [$this, 'add_sidebar_menu']);
+        hooks()->add_action('admin_init', [$this, 'load_language']);
+        hooks()->add_action('app_admin_head', [$this, 'add_assets']);
+    }
+
+    public function install()
+    {
+        $CI = get_instance();
+        $CI->load->library('migration');
+        $CI->migration->latest();
+
+        $default = [
+            'id'                        => 1,
+            'api_key'                   => '',
+            'service_account_credentials' => '',
+            'google_email'              => '',
+            'enabled_features'          => json_encode([
+                'email'    => true,
+                'calendar' => true,
+                'meet'     => true,
+                'drive'    => true,
+                'docs'     => true,
+            ]),
+        ];
+        $CI->db->insert(db_prefix() . 'google_workspace_settings', $default);
+        return true;
+    }
+
+    public function uninstall()
+    {
+        $CI = get_instance();
+        $CI->db->query('DROP TABLE IF EXISTS ' . db_prefix() . 'google_workspace_settings');
+        $CI->db->query('DROP TABLE IF EXISTS ' . db_prefix() . 'google_workspace_mappings');
+        return true;
+    }
+
+    public function add_sidebar_menu()
+    {
+        $CI = get_instance();
+        if (!isset($CI->app_menu)) {
+            return;
+        }
+        $CI->app_menu->add_sidebar_menu_item('google_workspace', [
+            'slug'     => 'google_workspace',
+            'name'     => _l('google_workspace'),
+            'href'     => admin_url('google_workspace'),
+            'icon'     => 'fa fa-google',
+            'position' => 40,
+        ]);
+    }
+
+    public function load_language()
+    {
+        $CI = get_instance();
+        $CI->lang->load('google_workspace/google_workspace', $CI->config->item('language'));
+    }
+
+    public function add_assets()
+    {
+        echo '<link rel="stylesheet" type="text/css" href="' . module_dir_url('google_workspace', 'assets/css/google_workspace.css') . '" />';
+        echo '<script src="' . module_dir_url('google_workspace', 'assets/js/google_workspace.js') . '"></script>';
+    }
+}

--- a/application/modules/google_workspace/language/english/google_workspace_lang.php
+++ b/application/modules/google_workspace/language/english/google_workspace_lang.php
@@ -1,0 +1,9 @@
+<?php
+$lang['google_workspace'] = 'Google Workspace';
+$lang['google_workspace_email'] = 'Gmail';
+$lang['google_workspace_calendar'] = 'Calendar';
+$lang['google_workspace_meet'] = 'Meet';
+$lang['google_workspace_drive'] = 'Drive';
+$lang['google_workspace_docs'] = 'Docs';
+$lang['google_workspace_settings'] = 'Settings';
+$lang['no_data_found'] = 'No data found';

--- a/application/modules/google_workspace/language/spanish/google_workspace_lang.php
+++ b/application/modules/google_workspace/language/spanish/google_workspace_lang.php
@@ -1,0 +1,9 @@
+<?php
+$lang['google_workspace'] = 'Google Workspace';
+$lang['google_workspace_email'] = 'Gmail';
+$lang['google_workspace_calendar'] = 'Calendario';
+$lang['google_workspace_meet'] = 'Meet';
+$lang['google_workspace_drive'] = 'Drive';
+$lang['google_workspace_docs'] = 'Documentos';
+$lang['google_workspace_settings'] = 'Configuración';
+$lang['no_data_found'] = 'No se encontraron datos';

--- a/application/modules/google_workspace/migrations/001_initial_setup.php
+++ b/application/modules/google_workspace/migrations/001_initial_setup.php
@@ -1,0 +1,72 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_Initial_setup extends CI_Migration
+{
+    public function up()
+    {
+        if (!$this->db->table_exists(db_prefix() . 'google_workspace_settings')) {
+            $this->dbforge->add_field([
+                'id' => [
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'unsigned' => true,
+                    'auto_increment' => true,
+                ],
+                'api_key' => [
+                    'type' => 'TEXT',
+                    'null' => true,
+                ],
+                'service_account_credentials' => [
+                    'type' => 'LONGTEXT',
+                    'null' => true,
+                ],
+                'google_email' => [
+                    'type' => 'VARCHAR',
+                    'constraint' => 100,
+                    'null' => true,
+                ],
+                'enabled_features' => [
+                    'type' => 'TEXT',
+                    'null' => true,
+                ],
+            ]);
+            $this->dbforge->add_key('id', true);
+            $this->dbforge->create_table(db_prefix() . 'google_workspace_settings');
+        }
+
+        if (!$this->db->table_exists(db_prefix() . 'google_workspace_mappings')) {
+            $this->dbforge->add_field([
+                'id' => [
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'unsigned' => true,
+                    'auto_increment' => true,
+                ],
+                'staff_id' => [
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'unsigned' => true,
+                ],
+                'google_email' => [
+                    'type' => 'VARCHAR',
+                    'constraint' => 100,
+                    'null' => true,
+                ],
+                'google_label' => [
+                    'type' => 'VARCHAR',
+                    'constraint' => 100,
+                    'null' => true,
+                ],
+            ]);
+            $this->dbforge->add_key('id', true);
+            $this->dbforge->create_table(db_prefix() . 'google_workspace_mappings');
+        }
+    }
+
+    public function down()
+    {
+        $this->dbforge->drop_table(db_prefix() . 'google_workspace_settings', true);
+        $this->dbforge->drop_table(db_prefix() . 'google_workspace_mappings', true);
+    }
+}

--- a/application/modules/google_workspace/views/calendar.php
+++ b/application/modules/google_workspace/views/calendar.php
@@ -1,0 +1,14 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed'); ?>
+<h1><?php echo _l('google_workspace_calendar'); ?></h1>
+<?php if (!empty($events)) { ?>
+<ul class="google-workspace-list">
+    <?php foreach ($events as $event) { ?>
+    <li>
+        <strong><?php echo htmlspecialchars($event['summary']); ?></strong>
+        <div><?php echo htmlspecialchars($event['start']); ?> - <?php echo htmlspecialchars($event['end']); ?></div>
+    </li>
+    <?php } ?>
+</ul>
+<?php } else { ?>
+<p><?php echo _l('no_data_found'); ?></p>
+<?php } ?>

--- a/application/modules/google_workspace/views/dashboard.php
+++ b/application/modules/google_workspace/views/dashboard.php
@@ -1,0 +1,12 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed'); ?>
+<div class="google-workspace-dashboard">
+    <h1><?php echo _l('google_workspace'); ?></h1>
+    <ul class="google-workspace-list">
+        <li><a href="<?php echo admin_url('google_workspace/email'); ?>"><?php echo _l('google_workspace_email'); ?></a></li>
+        <li><a href="<?php echo admin_url('google_workspace/calendar'); ?>"><?php echo _l('google_workspace_calendar'); ?></a></li>
+        <li><a href="<?php echo admin_url('google_workspace/meet'); ?>"><?php echo _l('google_workspace_meet'); ?></a></li>
+        <li><a href="<?php echo admin_url('google_workspace/drive'); ?>"><?php echo _l('google_workspace_drive'); ?></a></li>
+        <li><a href="<?php echo admin_url('google_workspace/docs'); ?>"><?php echo _l('google_workspace_docs'); ?></a></li>
+        <li><a href="<?php echo admin_url('google_workspace/settings'); ?>"><?php echo _l('google_workspace_settings'); ?></a></li>
+    </ul>
+</div>

--- a/application/modules/google_workspace/views/docs.php
+++ b/application/modules/google_workspace/views/docs.php
@@ -1,0 +1,15 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed'); ?>
+<h1><?php echo _l('google_workspace_docs'); ?></h1>
+<?php if (!empty($docs)) { ?>
+<ul class="google-workspace-list">
+    <?php foreach ($docs as $doc) { ?>
+    <li>
+        <a href="<?php echo htmlspecialchars($doc['webViewLink']); ?>" target="_blank">
+            <?php echo htmlspecialchars($doc['name']); ?>
+        </a>
+    </li>
+    <?php } ?>
+</ul>
+<?php } else { ?>
+<p><?php echo _l('no_data_found'); ?></p>
+<?php } ?>

--- a/application/modules/google_workspace/views/drive.php
+++ b/application/modules/google_workspace/views/drive.php
@@ -1,0 +1,15 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed'); ?>
+<h1><?php echo _l('google_workspace_drive'); ?></h1>
+<?php if (!empty($files)) { ?>
+<ul class="google-workspace-list">
+    <?php foreach ($files as $file) { ?>
+    <li>
+        <a href="<?php echo htmlspecialchars($file['webViewLink']); ?>" target="_blank">
+            <?php echo htmlspecialchars($file['name']); ?>
+        </a>
+    </li>
+    <?php } ?>
+</ul>
+<?php } else { ?>
+<p><?php echo _l('no_data_found'); ?></p>
+<?php } ?>

--- a/application/modules/google_workspace/views/email.php
+++ b/application/modules/google_workspace/views/email.php
@@ -1,0 +1,14 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed'); ?>
+<h1><?php echo _l('google_workspace_email'); ?></h1>
+<?php if (!empty($emails)) { ?>
+<ul class="google-workspace-list">
+    <?php foreach ($emails as $email) { ?>
+    <li>
+        <strong><?php echo htmlspecialchars($email['subject']); ?></strong>
+        <div><?php echo htmlspecialchars($email['snippet']); ?></div>
+    </li>
+    <?php } ?>
+</ul>
+<?php } else { ?>
+<p><?php echo _l('no_data_found'); ?></p>
+<?php } ?>

--- a/application/modules/google_workspace/views/meet.php
+++ b/application/modules/google_workspace/views/meet.php
@@ -1,0 +1,11 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed'); ?>
+<h1><?php echo _l('google_workspace_meet'); ?></h1>
+<?php if (!empty($meetings)) { ?>
+<ul class="google-workspace-list">
+    <?php foreach ($meetings as $meeting) { ?>
+    <li><?php echo htmlspecialchars($meeting['summary'] ?? ''); ?></li>
+    <?php } ?>
+</ul>
+<?php } else { ?>
+<p><?php echo _l('no_data_found'); ?></p>
+<?php } ?>

--- a/application/modules/google_workspace/views/settings.php
+++ b/application/modules/google_workspace/views/settings.php
@@ -1,0 +1,24 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed'); ?>
+<h1><?php echo _l('google_workspace_settings'); ?></h1>
+<form method="post">
+    <div class="form-group">
+        <label for="api_key">API Key</label>
+        <input type="text" class="form-control" name="api_key" value="<?php echo html_escape($settings['api_key'] ?? ''); ?>">
+    </div>
+    <div class="form-group">
+        <label for="service_account_credentials">Service Account Credentials (JSON)</label>
+        <textarea class="form-control" name="service_account_credentials" rows="5"><?php echo html_escape($settings['service_account_credentials'] ?? ''); ?></textarea>
+    </div>
+    <div class="form-group">
+        <label for="google_email">Admin Google Email</label>
+        <input type="text" class="form-control" name="google_email" value="<?php echo html_escape($settings['google_email'] ?? ''); ?>">
+    </div>
+    <?php $features = json_decode($settings['enabled_features'] ?? '{}', true); ?>
+    <div class="form-group">
+        <label>Enabled Features</label><br>
+        <?php foreach(['email','calendar','meet','drive','docs'] as $feat){ ?>
+        <label><input type="checkbox" name="enabled_features[<?php echo $feat; ?>]" value="1" <?php echo !empty($features[$feat]) ? 'checked' : ''; ?>> <?php echo _l('google_workspace_'.$feat); ?></label><br>
+        <?php } ?>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>


### PR DESCRIPTION
## Summary
- implement module bootstrap with install/uninstall callbacks and menu
- add default config
- create initial database migration
- implement controller actions and minimal views
- add simple CSS/JS assets
- provide English and Spanish language files

## Testing
- `composer install`
- `find application/modules/google_workspace -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68769b0433e88323b72b83c26a873636