### PR TITLE
Remove unsupported Meet scope

### DIFF
--- a/application/modules/google_workspace/libraries/Google_api.php
+++ b/application/modules/google_workspace/libraries/Google_api.php
@@ -26,8 +26,9 @@ class Google_api
             Google_Service_Gmail::GMAIL_MODIFY,
             Google_Service_Calendar::CALENDAR,
             Google_Service_Drive::DRIVE,
-            Google_Service_Docs::DOCUMENTS,
-            'https://www.googleapis.com/auth/meetings',
+            Google_Service_Docs::DOCUMENTS
+            // Google Meet does not have a dedicated API scope.
+            // Calendar scope provides access to create conference links.
         ]);
         $this->client->setSubject($settings['google_email']); // Impersonate admin email
     }
@@ -64,6 +65,7 @@ class Google_api
         return $this->services['docs'];
     }
 
-    // Add similar methods for other services (e.g., Meet)
+    // Meet functionality is handled via the Calendar service
+    // by generating conference links when creating events.
 }
 ?>

--- a/application/modules/google_workspace/models/Google_workspace_model.php
+++ b/application/modules/google_workspace/models/Google_workspace_model.php
@@ -107,7 +107,8 @@ class Google_workspace_model extends App_Model
 
     public function get_meetings($staff_id)
     {
-        // Placeholder for Google Meet API (not fully public, may require Calendar API for meeting links)
+        // Google currently exposes Meet features through the Calendar API.
+        // Use events with conference data to manage meeting links.
         return [];
     }
 


### PR DESCRIPTION
## Summary
- remove custom Google Meet scope since no official API exists
- clarify that Meet links are managed via Calendar

## Testing
- `php -l application/modules/google_workspace/libraries/Google_api.php`
- `php -l application/modules/google_workspace/models/Google_workspace_model.php`


------
https://chatgpt.com/codex/tasks/task_e_68769b076c3c8323aa613cdacaa0f34b