### PR TITLE
Add feature checks in Google Workspace module

### DIFF
--- a/application/modules/google_workspace/controllers/Google_workspace.php
+++ b/application/modules/google_workspace/controllers/Google_workspace.php
@@ -9,6 +9,19 @@ class Google_workspace extends AdminController
         $this->load->model('google_workspace/google_workspace_model');
     }
 
+    private function feature_enabled($feature)
+    {
+        $settings = $this->google_workspace_model->get_settings();
+        $features = json_decode($settings['enabled_features'] ?? '{}', true);
+        return !empty($features[$feature]);
+    }
+
+    private function feature_disabled_redirect()
+    {
+        set_alert('warning', _l('google_workspace_feature_disabled'));
+        redirect(admin_url('google_workspace'));
+    }
+
     public function index()
     {
         if (!has_permission('google_workspace', '', 'view')) {
@@ -23,6 +36,9 @@ class Google_workspace extends AdminController
         if (!has_permission('google_workspace', '', 'view')) {
             access_denied('google_workspace');
         }
+        if (!$this->feature_enabled('email')) {
+            $this->feature_disabled_redirect();
+        }
         $data['title']  = _l('google_workspace_email');
         $data['emails'] = $this->google_workspace_model->get_emails(get_staff_user_id());
         $this->load->view('google_workspace/email', $data);
@@ -32,6 +48,9 @@ class Google_workspace extends AdminController
     {
         if (!has_permission('google_workspace', '', 'view')) {
             access_denied('google_workspace');
+        }
+        if (!$this->feature_enabled('calendar')) {
+            $this->feature_disabled_redirect();
         }
         $data['title']  = _l('google_workspace_calendar');
         $data['events'] = $this->google_workspace_model->get_calendar_events(get_staff_user_id());
@@ -43,6 +62,9 @@ class Google_workspace extends AdminController
         if (!has_permission('google_workspace', '', 'view')) {
             access_denied('google_workspace');
         }
+        if (!$this->feature_enabled('meet')) {
+            $this->feature_disabled_redirect();
+        }
         $data['title']    = _l('google_workspace_meet');
         $data['meetings'] = $this->google_workspace_model->get_meetings(get_staff_user_id());
         $this->load->view('google_workspace/meet', $data);
@@ -53,6 +75,9 @@ class Google_workspace extends AdminController
         if (!has_permission('google_workspace', '', 'view')) {
             access_denied('google_workspace');
         }
+        if (!$this->feature_enabled('drive')) {
+            $this->feature_disabled_redirect();
+        }
         $data['title'] = _l('google_workspace_drive');
         $data['files'] = $this->google_workspace_model->get_drive_files(get_staff_user_id());
         $this->load->view('google_workspace/drive', $data);
@@ -62,6 +87,9 @@ class Google_workspace extends AdminController
     {
         if (!has_permission('google_workspace', '', 'view')) {
             access_denied('google_workspace');
+        }
+        if (!$this->feature_enabled('docs')) {
+            $this->feature_disabled_redirect();
         }
         $data['title'] = _l('google_workspace_docs');
         $data['docs']  = $this->google_workspace_model->get_docs(get_staff_user_id());

--- a/application/modules/google_workspace/language/english/google_workspace_lang.php
+++ b/application/modules/google_workspace/language/english/google_workspace_lang.php
@@ -11,3 +11,4 @@ $lang['email_from'] = 'From';
 $lang['email_subject'] = 'Subject';
 $lang['email_date'] = 'Date';
 $lang['email_snippet'] = 'Snippet';
+$lang['google_workspace_feature_disabled'] = 'This feature is disabled.';

--- a/application/modules/google_workspace/language/spanish/google_workspace_lang.php
+++ b/application/modules/google_workspace/language/spanish/google_workspace_lang.php
@@ -11,3 +11,4 @@ $lang['email_from'] = 'De';
 $lang['email_subject'] = 'Asunto';
 $lang['email_date'] = 'Fecha';
 $lang['email_snippet'] = 'Fragmento';
+$lang['google_workspace_feature_disabled'] = 'Esta función está deshabilitada.';


### PR DESCRIPTION
## Summary
- ensure Google Workspace pages only load when their feature is enabled
- show a warning when a disabled feature is accessed
- add translations for the new warning message

## Testing
- `composer install`
- `php -l application/modules/google_workspace/controllers/Google_workspace.php`


------
https://chatgpt.com/codex/tasks/task_e_68790505c514832395985dbb18098e63